### PR TITLE
Isolate default RPC endpoints and add type support for http URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weaverfi",
-  "version": "1.35.0",
+  "version": "1.35.1",
   "description": "The NPM package to query DeFi.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/chain-functions.ts
+++ b/src/chain-functions.ts
@@ -3,7 +3,7 @@
 import * as ens from './ens';
 import * as $ from './prices';
 import * as evm from './functions';
-import { chains, defaultRPCEndpoints } from './chains';
+import { chains, defaultRpcEndpoints } from './chains';
 import { projects } from './projects';
 import { WeaverError } from './error';
 
@@ -185,7 +185,7 @@ export class ChainFunctions {
   setCustomRpcEndpoints(rpcs: URL[], options?: { includeDefaults?: boolean }) {
     if(rpcs.length > 0) {
       if(options?.includeDefaults) {
-        chains[this.chain].rpcs = [...rpcs, ...defaultRPCEndpoints[this.chain]];
+        chains[this.chain].rpcs = [...rpcs, ...defaultRpcEndpoints[this.chain]];
       } else {
         chains[this.chain].rpcs = [...rpcs];
       }

--- a/src/chain-functions.ts
+++ b/src/chain-functions.ts
@@ -3,7 +3,7 @@
 import * as ens from './ens';
 import * as $ from './prices';
 import * as evm from './functions';
-import { chains } from './chains';
+import { chains, defaultRPCEndpoints } from './chains';
 import { projects } from './projects';
 import { WeaverError } from './error';
 
@@ -185,7 +185,7 @@ export class ChainFunctions {
   setCustomRpcEndpoints(rpcs: URL[], options?: { includeDefaults?: boolean }) {
     if(rpcs.length > 0) {
       if(options?.includeDefaults) {
-        chains[this.chain].rpcs = [...rpcs, ...chains[this.chain].rpcs];
+        chains[this.chain].rpcs = [...rpcs, ...defaultRPCEndpoints[this.chain]];
       } else {
         chains[this.chain].rpcs = [...rpcs];
       }

--- a/src/chains.ts
+++ b/src/chains.ts
@@ -2,8 +2,10 @@
 // Type Imports:
 import type { Chain, ChainData, URL } from './types';
 
-// Default chain RPC Endpoints:
-export const defaultRPCEndpoints: Record<Chain, URL[]> = {
+/* ========================================================================================================================================================================= */
+
+// Default chain RPC endpoints:
+export const defaultRpcEndpoints: Record<Chain, URL[]> = {
   eth: [
     'https://mainnet.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161',
     'https://eth-rpc.gateway.pokt.network',
@@ -42,7 +44,9 @@ export const defaultRPCEndpoints: Record<Chain, URL[]> = {
     'https://arb1.arbitrum.io/rpc',
     'https://rpc.ankr.com/arbitrum'
   ]
-};
+}
+
+/* ========================================================================================================================================================================= */
 
 // Exporting Chain Data:
 export const chains: Record<Chain, ChainData> = {
@@ -55,7 +59,7 @@ export const chains: Record<Chain, ChainData> = {
     usdcDecimals: 6,
     inch: true,
     paraswap: true,
-    rpcs: [...defaultRPCEndpoints.eth],
+    rpcs: [...defaultRpcEndpoints.eth],
     coingeckoIDs: {
       chainID: 'ethereum',
       nativeTokenID: 'ethereum'
@@ -71,7 +75,7 @@ export const chains: Record<Chain, ChainData> = {
     usdcDecimals: 18,
     inch: true,
     paraswap: true,
-    rpcs: [...defaultRPCEndpoints.bsc],
+    rpcs: [...defaultRpcEndpoints.bsc],
     coingeckoIDs: {
       chainID: 'binance-smart-chain',
       nativeTokenID: 'binancecoin'
@@ -87,7 +91,7 @@ export const chains: Record<Chain, ChainData> = {
     usdcDecimals: 6,
     inch: true,
     paraswap: true,
-    rpcs: [...defaultRPCEndpoints.poly],
+    rpcs: [...defaultRpcEndpoints.poly],
     coingeckoIDs: {
       chainID: 'polygon-pos',
       nativeTokenID: 'matic-network'
@@ -103,7 +107,7 @@ export const chains: Record<Chain, ChainData> = {
     usdcDecimals: 6,
     inch: false,
     paraswap: true,
-    rpcs: [...defaultRPCEndpoints.ftm],
+    rpcs: [...defaultRpcEndpoints.ftm],
     coingeckoIDs: {
       chainID: 'fantom',
       nativeTokenID: 'fantom'
@@ -119,7 +123,7 @@ export const chains: Record<Chain, ChainData> = {
     usdcDecimals: 6,
     inch: true,
     paraswap: true,
-    rpcs: [...defaultRPCEndpoints.avax],
+    rpcs: [...defaultRpcEndpoints.avax],
     coingeckoIDs: {
       chainID: 'avalanche',
       nativeTokenID: 'avalanche-2'
@@ -135,7 +139,7 @@ export const chains: Record<Chain, ChainData> = {
     usdcDecimals: 6,
     inch: false,
     paraswap: false,
-    rpcs: [...defaultRPCEndpoints.cronos],
+    rpcs: [...defaultRpcEndpoints.cronos],
     coingeckoIDs: {
       chainID: 'cronos',
       nativeTokenID: 'crypto-com-chain'
@@ -151,7 +155,7 @@ export const chains: Record<Chain, ChainData> = {
     usdcDecimals: 6,
     inch: true,
     paraswap: false,
-    rpcs: [...defaultRPCEndpoints.op],
+    rpcs: [...defaultRpcEndpoints.op],
     coingeckoIDs: {
       chainID: 'optimistic-ethereum',
       nativeTokenID: 'ethereum'
@@ -167,7 +171,7 @@ export const chains: Record<Chain, ChainData> = {
     usdcDecimals: 6,
     inch: true,
     paraswap: true,
-    rpcs: [...defaultRPCEndpoints.arb],
+    rpcs: [...defaultRpcEndpoints.arb],
     coingeckoIDs: {
       chainID: 'arbitrum-one',
       nativeTokenID: 'ethereum'

--- a/src/chains.ts
+++ b/src/chains.ts
@@ -1,6 +1,48 @@
 
 // Type Imports:
-import type { Chain, ChainData } from './types';
+import type { Chain, ChainData, URL } from './types';
+
+// Default chain RPC Endpoints:
+export const defaultRPCEndpoints: Record<Chain, URL[]> = {
+  eth: [
+    'https://mainnet.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161',
+    'https://eth-rpc.gateway.pokt.network',
+    'https://rpc.ankr.com/eth'
+  ],
+  bsc: [
+    'https://bsc-dataseed.binance.org',
+    'https://bsc-mainnet.gateway.pokt.network/v1/lb/6136201a7bad1500343e248d',
+    'https://rpc.ankr.com/bsc'
+  ],
+  poly: [
+    'https://polygon-rpc.com',
+    'https://poly-rpc.gateway.pokt.network/',
+    'https://rpc.ankr.com/polygon'
+  ],
+  ftm: [
+    'https://rpc.ftm.tools/',
+    'https://rpcapi.fantom.network',
+    'https://rpc.ankr.com/fantom'
+  ],
+  avax: [
+    'https://api.avax.network/ext/bc/C/rpc',
+    'https://avax-mainnet.gateway.pokt.network/v1/lb/605238bf6b986eea7cf36d5e/ext/bc/C/rpc',
+    'https://rpc.ankr.com/avalanche'
+  ],
+  cronos: [
+    'https://evm-cronos.crypto.org',
+    'https://rpc.vvs.finance'
+  ],
+  op: [
+    'https://optimism-mainnet.public.blastapi.io',
+    'https://mainnet.optimism.io',
+    'https://rpc.ankr.com/optimism'
+  ],
+  arb: [
+    'https://arb1.arbitrum.io/rpc',
+    'https://rpc.ankr.com/arbitrum'
+  ]
+};
 
 // Exporting Chain Data:
 export const chains: Record<Chain, ChainData> = {
@@ -13,11 +55,7 @@ export const chains: Record<Chain, ChainData> = {
     usdcDecimals: 6,
     inch: true,
     paraswap: true,
-    rpcs: [
-      'https://mainnet.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161',
-      'https://eth-rpc.gateway.pokt.network',
-      'https://rpc.ankr.com/eth'
-    ],
+    rpcs: [...defaultRPCEndpoints.eth],
     coingeckoIDs: {
       chainID: 'ethereum',
       nativeTokenID: 'ethereum'
@@ -33,11 +71,7 @@ export const chains: Record<Chain, ChainData> = {
     usdcDecimals: 18,
     inch: true,
     paraswap: true,
-    rpcs: [
-      'https://bsc-dataseed.binance.org',
-      'https://bsc-mainnet.gateway.pokt.network/v1/lb/6136201a7bad1500343e248d',
-      'https://rpc.ankr.com/bsc'
-    ],
+    rpcs: [...defaultRPCEndpoints.bsc],
     coingeckoIDs: {
       chainID: 'binance-smart-chain',
       nativeTokenID: 'binancecoin'
@@ -53,11 +87,7 @@ export const chains: Record<Chain, ChainData> = {
     usdcDecimals: 6,
     inch: true,
     paraswap: true,
-    rpcs: [
-      'https://polygon-rpc.com',
-      'https://poly-rpc.gateway.pokt.network/',
-      'https://rpc.ankr.com/polygon'
-    ],
+    rpcs: [...defaultRPCEndpoints.poly],
     coingeckoIDs: {
       chainID: 'polygon-pos',
       nativeTokenID: 'matic-network'
@@ -73,11 +103,7 @@ export const chains: Record<Chain, ChainData> = {
     usdcDecimals: 6,
     inch: false,
     paraswap: true,
-    rpcs: [
-      'https://rpc.ftm.tools/',
-      'https://rpcapi.fantom.network',
-      'https://rpc.ankr.com/fantom'
-    ],
+    rpcs: [...defaultRPCEndpoints.ftm],
     coingeckoIDs: {
       chainID: 'fantom',
       nativeTokenID: 'fantom'
@@ -93,11 +119,7 @@ export const chains: Record<Chain, ChainData> = {
     usdcDecimals: 6,
     inch: true,
     paraswap: true,
-    rpcs: [
-      'https://api.avax.network/ext/bc/C/rpc',
-      'https://avax-mainnet.gateway.pokt.network/v1/lb/605238bf6b986eea7cf36d5e/ext/bc/C/rpc',
-      'https://rpc.ankr.com/avalanche'
-    ],
+    rpcs: [...defaultRPCEndpoints.avax],
     coingeckoIDs: {
       chainID: 'avalanche',
       nativeTokenID: 'avalanche-2'
@@ -113,10 +135,7 @@ export const chains: Record<Chain, ChainData> = {
     usdcDecimals: 6,
     inch: false,
     paraswap: false,
-    rpcs: [
-      'https://evm-cronos.crypto.org',
-      'https://rpc.vvs.finance'
-    ],
+    rpcs: [...defaultRPCEndpoints.cronos],
     coingeckoIDs: {
       chainID: 'cronos',
       nativeTokenID: 'crypto-com-chain'
@@ -132,11 +151,7 @@ export const chains: Record<Chain, ChainData> = {
     usdcDecimals: 6,
     inch: true,
     paraswap: false,
-    rpcs: [
-      'https://optimism-mainnet.public.blastapi.io',
-      'https://mainnet.optimism.io',
-      'https://rpc.ankr.com/optimism'
-    ],
+    rpcs: [...defaultRPCEndpoints.op],
     coingeckoIDs: {
       chainID: 'optimistic-ethereum',
       nativeTokenID: 'ethereum'
@@ -152,10 +167,7 @@ export const chains: Record<Chain, ChainData> = {
     usdcDecimals: 6,
     inch: true,
     paraswap: true,
-    rpcs: [
-      'https://arb1.arbitrum.io/rpc',
-      'https://rpc.ankr.com/arbitrum'
-    ],
+    rpcs: [...defaultRPCEndpoints.arb],
     coingeckoIDs: {
       chainID: 'arbitrum-one',
       nativeTokenID: 'ethereum'

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -803,7 +803,7 @@ export const getChainTokenData = (chain: Chain) => {
 export const getTokenLogo = (chain: Chain, symbol: string) => {
 
   // Initializing Default Token Logo:
-  let logo = defaultTokenLogo;
+  let logo: URL = defaultTokenLogo;
 
   // Selecting Token Data:
   let data = getChainTokenData(chain);

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,7 +22,7 @@ export type ABI = (ABIEntry | ExtendedABIEntry | ExtendedABIEventEntry | Extende
 export type ABIIOType = `int${number}` | `int${number}[${number | ''}]` | `uint${number}` | `uint${number}[${number | ''}]` | `bytes${number | ''}` | `bytes${number | ''}[${number | ''}]` | 'address' | `address[${number | ''}]` | 'bool' | `bool[${number | ''}]` | 'tuple' | `tuple[${number | ''}]` | 'string' | `string[${number | ''}]` | `contract ${string}` | `struct ${string}`;
 
 // Generic Types:
-export type URL = `https://${string}`;
+export type URL = `http${'s'|''}://${string}`;
 export type Hash = `0x${string}`;
 export type IPFS = `ipfs://${string}`;
 export type IPNS = `ipns://${string}`;


### PR DESCRIPTION
This request addresses two minor issues with RPC Endpoints:

1) Lack of HTTP typing support for local RPC endpoints (ex. http://localhost:8545/)
2) Setting custom RPC endpoints overwrites WeaverFi default RPC endpoints

The first issue was fixed by expanding the typing conditions for the `URL` type.

The second issue was fixed by isolating the default RPC endpoints from the current RPC endpoints in use for each chain. These defaults are then referenced and appended if requested on `setCustomRpcEndpoints(...)`